### PR TITLE
More descriptive error when job id is left blank on logs command.

### DIFF
--- a/logs.go
+++ b/logs.go
@@ -12,5 +12,9 @@ var cmdLogs = &Command{
 }
 
 func runLogs(cmd *Command, args []string) {
+	if len(args) != 1 {
+		panic("You must supply a job id")
+	}
+
 	must(Get(os.Stdout, "/apps/"+mustApp()+"/jobs/"+args[0]+"/logs"))
 }


### PR DESCRIPTION
This is a fix for the first part of #2. Not sure yet how best to handle http errors for the second part.
