### PR TITLE
Remove remote before adding.

### DIFF
--- a/app.go
+++ b/app.go
@@ -28,7 +28,8 @@ func runCreate(cmd *Command, args []string, client *controller.Client) error {
 	if err := client.CreateApp(app); err != nil {
 		return err
 	}
-
+	
+	exec.Command("git", "remote", "remove", "flynn").Run()
 	exec.Command("git", "remote", "add", "flynn", gitURLPre(serverConf.GitHost)+app.Name+gitURLSuf).Run()
 	log.Printf("Created %s", app.Name)
 	return nil


### PR DESCRIPTION
When the flynn server is replaced git remote add was failing silently when creating the app with the new server. It should either remove the previous server or issue a warning.
